### PR TITLE
Replace CentOS with Fedora for OpenShift

### DIFF
--- a/openshift/Dockerfile.centos
+++ b/openshift/Dockerfile.centos
@@ -1,10 +1,15 @@
-FROM fedora:29
+FROM centos:7
 
-RUN dnf install -y python2-ipykernel python2-jupyter-core gcc python2-devel \
-    bzip2 openssh openssh-clients python2-crypto python2-psutil glibc-locale-source && \
+# Install Ansible Jupyter Kernel
+RUN yum -y install epel-release  && \
+    yum -y install ansible python-psutil python-pip bzip2 python-crypto openssh openssh-clients gcc python-devel.x86_64 && \
     localedef -c -i en_US -f UTF-8 en_US.UTF-8 && \
     pip install --no-cache-dir wheel psutil && \
     rm -rf /var/cache/yum
+
+RUN pip install --no-cache-dir prompt-toolkit==1.0.15
+RUN pip install --no-cache-dir ipython==5.7
+RUN pip install --no-cache-dir ipykernel==4.10 
 
 ENV LANG=en_US.UTF-8 \
     LANGUAGE=en_US:en \

--- a/openshift/bin/run
+++ b/openshift/bin/run
@@ -2,4 +2,4 @@
 id
 whoami
 
-jupyter notebook --ip 0.0.0.0
+jupyter-notebook --ip 0.0.0.0

--- a/openshift/openshift-template.yaml
+++ b/openshift/openshift-template.yaml
@@ -12,17 +12,17 @@ objects:
 - apiVersion: v1
   kind: ImageStream
   metadata:
-    name: centos 
+    name: fedora 
 - apiVersion: image.openshift.io/v1
   kind: ImageStreamTag
   metadata:
-    name: centos:7
+    name: fedora:29 
   tag:
     from:
       kind: DockerImage
-      name: centos:7
+      name: fedora:29
     importPolicy: {}
-    name: "7"
+    name: "29"
     referencePolicy:
       type: Source
 - apiVersion: v1
@@ -130,7 +130,7 @@ objects:
       dockerStrategy:
         from:
           kind: ImageStreamTag
-          name: centos:7
+          name: fedora:29
       type: Docker
     triggers:
     - type: ConfigChange


### PR DESCRIPTION
## Status
**READY**

## Description
- Modified Dockerfile to use Fedora 29 instead of CentOS 7 because of issues with
pip install of notebook.
- Modified openshift-template to use fedora imagestream

## Impacted Areas in Application
List general components of the application that this PR will affect:
- OpenShift

