### PR TITLE
Added runner_on_start support

### DIFF
--- a/ansible_kernel/kernel.py
+++ b/ansible_kernel/kernel.py
@@ -324,6 +324,8 @@ class AnsibleKernel(Kernel):
                 pass
             elif event == 'playbook_on_include':
                 pass
+            elif event == 'runner_on_start':
+                pass
             elif event == 'playbook_on_task_start':
                 logger.debug('playbook_on_task_start')
                 task_args = event_data.get('task_args', [])


### PR DESCRIPTION
## Status
**READY**

## Description
event 'runner_on_start' is added Ansible 2.8.
Prevents it from being processed as an undefined event.
